### PR TITLE
FriendshipStatus loading, acceptFriendRequest fix

### DIFF
--- a/php/src/controllers/FriendshipController.php
+++ b/php/src/controllers/FriendshipController.php
@@ -72,7 +72,7 @@ class FriendshipController
             return array("status" => "UserIDs can't match.");
         }
 
-        if ($this->friendship->acceptFriendRequest()) {
+        if ($this->friendship->acceptFriendRequest($user->id)) {
             return array(
                 "status" => "Successfully accepted friend request!"
             );

--- a/php/src/models/Friendship.php
+++ b/php/src/models/Friendship.php
@@ -31,7 +31,7 @@ class Friendship
             if (!isset($this->friendshipStatus)) {
                 $this->friendshipStatus = new FriendshipStatus($this->conn);
                 $row = $stmt->fetch(PDO::FETCH_ASSOC);
-                $this->friendshipStatus->loadFromRow($row);
+                $this->friendshipStatus->loadFromDB($row['statusID']);
             }
             return true;
         }
@@ -96,9 +96,12 @@ class Friendship
         return false;
     }
 
-    public function acceptFriendRequest()
+    public function acceptFriendRequest($user)
     {
         if (!$this->doesFriendshipExist())
+            return false;
+
+        if (!$this->friendshipStatus->initiator == $user)
             return false;
 
         if ($this->friendshipStatus->updateStatus(1)) {

--- a/php/src/models/FriendshipStatus.php
+++ b/php/src/models/FriendshipStatus.php
@@ -12,11 +12,23 @@ class FriendshipStatus
         $this->conn = $db;
     }
 
-    public function loadFromRow($row)
+    public function loadFromDB($statusID)
     {
-        $this->statusID = $row['statusID'];
-        $this->initiator = $row['initiator'];
-        $this->status = $row['status'];
+        $query = "SELECT * FROM " . $this->status_table ."
+                WHERE 
+                    statusID = :statusID";
+            
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':statusID', $statusID);
+        $stmt->execute();
+        if ($stmt->rowCount() > 0) {
+            $row = $stmt->fetch(PDO::FETCH_ASSOC);
+            $this->statusID = $row['statusID'];
+            $this->initiator = $row['initiator'];
+            $this->status = $row['status'];
+            return true;
+        }
+        return false;
     }
 
     public function createNewEntry($initiator)


### PR DESCRIPTION
FriendshipStatus now properly loads itself from the database. A user can no longer accept a friend request that they sent.